### PR TITLE
Skipping policy first attempt

### DIFF
--- a/migrations/1_deploy_contracts.js
+++ b/migrations/1_deploy_contracts.js
@@ -1,8 +1,8 @@
 const LightClient = artifacts.require("LightClient");
 const UpdaterContract = artifacts.require("UpdaterContract");
 
-module.exports = function(deployer) {
+module.exports = function(deployer, skippingBlocksPolicy) {
     deployer.deploy(LightClient);
     deployer.link(LightClient, UpdaterContract);
-    deployer.deploy(UpdaterContract);
+    deployer.deploy(UpdaterContract, skippingBlocksPolicy);
 };

--- a/test/updater_contract.js
+++ b/test/updater_contract.js
@@ -6,7 +6,7 @@ const UpdaterContract = artifacts.require("UpdaterContract");
  */
 contract("UpdaterContract", function (accounts) {
     it("getBlockHeaderFields and getBlockHeaderHash", async function () {
-        const updaterContract = await UpdaterContract.deployed();
+        const updaterContract = await UpdaterContract.deployed(false);
 
         // Create fake block header 1
         const blockHeaderByteArray1 = new Uint8Array(600);
@@ -38,7 +38,7 @@ contract("UpdaterContract", function (accounts) {
         assert.equal(solComputedHash, blockHeaderHash1);
     });
     it("headerUpdate and getBlockHeader sanity", async function () {
-        const updaterContract = await UpdaterContract.deployed();
+        const updaterContract = await UpdaterContract.deployed(false);
 
         // Dummy block
         const blockHeaderByteArray0 = new Uint8Array(600);


### PR DESCRIPTION
Implement skipping policy by checking the sync committee (initial attempt)

Tested:

- [x] `solium -d .`
- [x] `truffle test` (+ no compiler warnings)
